### PR TITLE
Add 32bit architecture, terminal application, some fix attempts

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -9,8 +9,10 @@ source-code: https://git.launchpad.net/lutris-snap/tree/snapcraft.yaml
 issues:
   - https://github.com/sameersharma2006/lutris-snap/issues
   - https://bugs.launchpad.net/lutris-snap
+
 architectures:
-  - build-on: amd64
+  - build-on: [amd64]
+    build-for: [amd64]
 
 assumes:
   - snapd2.60
@@ -21,21 +23,30 @@ lint:
     - library:
       - usr/*
 
+package-repositories:
+  - type: apt
+    formats: [deb]
+    architectures: [i386]
+    components: [main]
+    suites: [jammy]
+    key-id: F23C5A6CF475977595C89F51BA6932366A755776
+    url: https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu
+
 layout:
   /usr/bin/vkcube:
     symlink: $SNAP/usr/bin/vkcube
   /usr/lib/$CRAFT_ARCH_TRIPLET/libvkd3d.so.1.1.0:
     symlink: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/libvkd3d.so.1.1.0
 
-apps: 
+apps:
   lutris:
     command: usr/bin/lutris
     extensions: [gnome]
     environment:
       APPIMAGE_EXTRACT_AND_RUN: 1
       PYTHONPATH: ${SNAP}/usr/lib/python3/dist-packages
-    common-id: net.lutris.Lutris 
-    desktop: usr/share/applications/net.lutris.Lutris.desktop 
+    common-id: net.lutris.Lutris
+    desktop: usr/share/applications/net.lutris.Lutris.desktop
     plugs:
       - home
       - unity7
@@ -56,12 +67,15 @@ apps:
       - system-observe
       - upower-observe
 
-slots:    
+  bash:
+    command: bin/bash
+
+slots:
   lutris:
     interface: dbus
     bus: session
-    name: net.lutris.Lutris  
-  
+    name: net.lutris.Lutris
+
 parts:
   lutris:
     source: https://github.com/lutris/lutris.git
@@ -72,8 +86,8 @@ parts:
       - --prefix=/usr
     override-pull: |
       craftctl default
-      sed -e 's|Icon=lutris|Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/lutris.svg|' -i  share/applications/net.lutris.Lutris.desktop 
-  
+      sed -e 's|Icon=lutris|Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/lutris.svg|' -i  share/applications/net.lutris.Lutris.desktop
+
   deps:
     after: [lutris]
     plugin: nil
@@ -84,20 +98,27 @@ parts:
       - p7zip-full
       - p7zip-rar
       - curl
-      - fluid-soundfont-gs 
+      - kitty
+      - bash
+      - fluid-soundfont-gs
       - pciutils
       - libpci3
       - mesa-vulkan-drivers
       - vulkan-tools
-      - libvulkan1
-      - libvkd3d1
+      - libxcb1:i386
+      - libxcb1:amd64
+      - libgl1:i386
+      - libvulkan1:i386
+      - libvulkan1:amd64
     prime:
       - bin/fuser
+      - bin/bash
       - usr/bin/killall
       - usr/bin/peekfd
       - usr/bin/prtstat
       - usr/bin/pslog
       - usr/bin/pstree
+      - usr/bin/kitty
       - usr/share/menu/psmisc
       - usr/share/pixmaps/pstree16.xpm
       - usr/share/pixmaps/pstree32.xpm
@@ -126,7 +147,10 @@ parts:
       - usr/lib/*/libVk*
       - usr/lib/*/libvulkan*
       - usr/lib/*/libvkd3d*
-      
+      - usr/lib/*/libxcb*
+      - usr/lib/*/libX11*
+
+
   py-deps:
     after: [deps]
     plugin: nil
@@ -201,7 +225,7 @@ parts:
       - usr/bin/es2*
       - usr/bin/egl*
       - usr/share/mesa-demos
-      
+
   wine-deps:
     after: [sundry]
     plugin: nil
@@ -211,6 +235,7 @@ parts:
       - fluidsynth
       - gamemode
       - wine64
+      - wine
     prime:
       - usr/lib/*/wine
       - usr/share/wine
@@ -227,9 +252,8 @@ parts:
       - usr/share/dbus-1/services/com.feralinteractive.GameMode.service
       - usr/share/gamemode
       - usr/lib/*/libgamemode
-      - usr/lib/wine/wine64
-      - usr/lib/wine/wineserver64
-      
+      - usr/lib/wine/wine*
+
   cleanup:
     after:
       - wine-deps


### PR DESCRIPTION
This add the 32bit support for Ubuntu packages.
It also adds a terminal application, the same we use in the flatpak but it doesn't work yet. 
I tried to add libxcb* but they're not appearing in the 64bit lib folder, only the 32bit one...
Also installed 32bit Wine but it is still not detected as installed in Lutris.